### PR TITLE
Linux Support

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -58,7 +58,9 @@ namespace VoiceChannelGrabber
 
             try
             {
+                #if Windows
                 Native.SetQuickEditMode(false);
+                #endif
                 MainAsync().Wait();
                 return 0;
             }
@@ -323,12 +325,35 @@ namespace VoiceChannelGrabber
             }
         }
 
+        private static void EnsureDiscordIpcSymlink(int pipeNumber = 0)
+        {
+            if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+
+            string pipeName = "discord-ipc-" + pipeNumber;
+            string xdgRuntime = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR")
+                ?? "/run/user/" + getuid();
+            string socketPath = Path.Combine(xdgRuntime, pipeName);
+            string symlinkPath = "/tmp/CoreFxPipe_" + pipeName;
+
+            if (File.Exists(socketPath))
+            {
+                // Remove stale symlink
+                try { File.Delete(symlinkPath); } catch { }
+                File.CreateSymbolicLink(symlinkPath, socketPath);
+                Log.Logger.Debug("Created symlink {Symlink} -> {Socket}", symlinkPath, socketPath);
+            }
+        }
+
+        [System.Runtime.InteropServices.DllImport("libc")]
+        private static extern uint getuid();
+
         private static async Task WaitForDiscordClient()
         {
             while (!IsDiscordAvailable)
             {
                 try
                 {
+                    EnsureDiscordIpcSymlink();
                     await client.InitAsync();
                     IsDiscordAvailable = true;
                     Log.Logger.Information("Connected to local Discord client.");

--- a/Program.cs
+++ b/Program.cs
@@ -220,9 +220,17 @@ namespace VoiceChannelGrabber
             if (IsOBSconnected) Log.Logger.Warning("Websocket connection lost. Waiting for OBS...");
             IsOBSconnected = false;
 
+            if (obs != null)
+            {
+                obs.Connected -= obsOnConnect;
+                obs.Disconnected -= obsOnDisconnect;
+                if (obs.IsConnected)
+                    try { obs.Disconnect(); } catch { }
+            }
+
+            Thread.Sleep(2000);
+
             obs = new OBSWebsocket();
-            obs.Connected -= obsOnConnect;
-            obs.Disconnected -= obsOnDisconnect;
             obs.Connected += obsOnConnect;
             obs.Disconnected += obsOnDisconnect;
             obs.ConnectAsync(Config.WebsocketAddress, Config.WebsocketPassword);

--- a/VoiceChannelGrabber.csproj
+++ b/VoiceChannelGrabber.csproj
@@ -13,6 +13,18 @@
     <Product>VoiceChannelGrabber</Product>
     <RepositoryUrl>https://github.com/dichternebel/voice-channel-grabber.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX> 
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux> 
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsOSX)'=='true'">
+    <DefineConstants>OSX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsLinux)'=='true'">
+    <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The existing codebase is already pretty close to natively supporting Linux, so I added a couple changes to get it to the rest of the way.

First I added a compiler directive for the platform check to remove the Native call so that the program no longer directly relies on Kernel32. I think Windows is the only one that has a concept of Quick Edit anyway.

Second, due to the way named pipes are handled under Linux, a symlink also needs to be performed so that `$XDG_RUNTIME_DIR/discord-ipc-{pipenum}` maps cleanly to `/tmp/CoreFxPipe_discord-ipc-{pipenum}`. The dev behind DiscordIPC discontinued development in favor of a Rust binary that is unreleased, so this is a workaround until that project is ready.